### PR TITLE
Hide HUD and Break overlay with Autoplay mode.

### DIFF
--- a/osu.Game.Rulesets.Mvis/Mods/MvisModAutoplay.cs
+++ b/osu.Game.Rulesets.Mvis/Mods/MvisModAutoplay.cs
@@ -4,16 +4,28 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Users;
 using osu.Game.Rulesets.Mvis.Replays;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Rulesets.Mvis.Mods
 {
-    public class MvisModAutoplay : ModAutoplay<MvisHitObject>
+    public class MvisModAutoplay : ModAutoplay<MvisHitObject>, IApplicableToHUD, IApplicableToPlayer
     {
         public override Score CreateReplayScore(IBeatmap beatmap) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "bosu!" } },
             Replay = new MvisAutoGenerator(beatmap).Generate(),
         };
+
+        public void ApplyToHUD(HUDOverlay overlay)
+        {
+            overlay.ShowHud.Value = false;
+            overlay.ShowHud.Disabled = true;
+        }
+
+        public void ApplyToPlayer(Player player)
+        {
+            player.BreakOverlay.Hide();
+        }
 
         public override string Description => "Use if you want to avoid auto-pause while using another window";
     }


### PR DESCRIPTION
This should provide a workaround for #1 by inheriting `IApplicableToPlayer` in `MvisModAutoplay` to disable the break overlay. It inherits `IApplicableToHUD` to hide the HUD as well for a better immersion.